### PR TITLE
Change save process for plates to store full Float values instead of Uint16 converted values.

### DIFF
--- a/noncompiled/JsonSerializer.js
+++ b/noncompiled/JsonSerializer.js
@@ -53,9 +53,9 @@ JsonSerializer.plate = function (plate, options) {
 
 	// encode in base64
 	plate_json.ids 	= Base64.encode(Uint16Array.from( Uint16Raster .get_mask(plate.grid.vertex_ids,	plate.mask) ).buffer);
-	plate_json.sima = Base64.encode(Uint16Array.from( Float32Raster.get_mask(plate.sima, 			plate.mask) ).buffer);
-	plate_json.sial = Base64.encode(Uint16Array.from( Float32Raster.get_mask(plate.sial, 			plate.mask) ).buffer);
-	plate_json.age 	= Base64.encode(Uint16Array.from( Float32Raster.get_mask(plate.age, 			plate.mask) ).buffer);
+	plate_json.sima = Base64.encode(                  Float32Raster.get_mask(plate.sima,            plate.mask)  .buffer);
+	plate_json.sial = Base64.encode(                  Float32Raster.get_mask(plate.sial,            plate.mask)  .buffer);
+	plate_json.age 	= Base64.encode(                  Float32Raster.get_mask(plate.age,             plate.mask)  .buffer);
 
 	return plate_json;
 }
@@ -74,9 +74,9 @@ JsonDeserializer.plate = function (plate_json, _world, options) {
 
 	var file_ids = new Uint16Array(Base64.decode(plate_json.ids));
 	Uint8Raster.set_ids_to_value	(plate.mask, 	file_ids, 1);
-	Float32Raster.set_ids_to_values	(plate.sima, 	file_ids, new Uint16Array(Base64.decode(plate_json.sima)) );
-	Float32Raster.set_ids_to_values	(plate.sial, 	file_ids, new Uint16Array(Base64.decode(plate_json.sial)) );
-	Float32Raster.set_ids_to_values	(plate.age, 	file_ids, new Uint16Array(Base64.decode(plate_json.age))  );
+	Float32Raster.set_ids_to_values	(plate.sima, 	file_ids, new Float32Array(Base64.decode(plate_json.sima)) );
+	Float32Raster.set_ids_to_values	(plate.sial, 	file_ids, new Float32Array(Base64.decode(plate_json.sial)) );
+	Float32Raster.set_ids_to_values	(plate.age, 	file_ids, new Float32Array(Base64.decode(plate_json.age))  );
 
 	return plate;
 }


### PR DESCRIPTION
Three of the plate arrays being saved (sima,sial,age) all seem to be Float32Array. Converting these arrays to Uint16Array seems to lose any fractional portion of values. The ".buffer" of a Float32Array can just as easily be fed into Base64.encode, and will yield more precise plate data upon reload.

The size of the save-file does increase somewhat with this change. But the reloaded maps seem to match what I attempted to save more closely. I still see some differences between the "pre-save" and "post-load" maps when looking at the "plates" ScalarDisplay, but this change made things a lot better for me.

Before I was having large lakes appear when re-loading that were not present when I saved. I think in addition to saving the fractional component now, if the float values were > max_Uint16, those values area also being preserved now in the savefile.