### PR TITLE
Fix autosave function

### DIFF
--- a/index.html
+++ b/index.html
@@ -685,7 +685,7 @@
 
     function autosave() {
         if (!autosave_period) { return; }
-        setTimeout(update, 1000*autosave_period);
+        setTimeout(autosave, 1000*autosave_period);
         saveVue.save();
     }
 


### PR DESCRIPTION
The autosave function was only saving at time zero, because the setTimeout was calling the update() method instead of calling autosave() again.